### PR TITLE
Update response model to handle property array

### DIFF
--- a/src/query_graph.py
+++ b/src/query_graph.py
@@ -18,11 +18,11 @@ def _query_template():
             inE('has_version').outV().hasLabel('dependency').{dependency_query}.
           as('dependency').
           select('feedback', 'security_event', 'probable_vulnerability', 'dependency_version', 'dependency').
-          by(inE().outV().valueMap().by(unfold()).fold()).
-          by(valueMap().by(unfold())).
-          by(valueMap().by(unfold())).
-          by(valueMap().by(unfold())).
-          by(valueMap().by(unfold()))'''
+          by(inE().outV().valueMap().fold()).
+          by(valueMap()).
+          by(valueMap()).
+          by(valueMap()).
+          by(valueMap())'''
 
 def _identity_or_conditional(query):
     return 'identity()' if len(query) == 0 else '.'.join(query)

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -11,8 +11,7 @@ from src.rest_model import POST_PCVE, GET_PCVE, POST_FEEDBACK, PARSER
 class RestApi(Resource):
     """Abstracts REST end-point routers"""
     @api.expect(PARSER)
-    @api.marshal_list_with(GET_PCVE, skip_none=True,
-                           mask='*,feedback{author, comments, feedback_type}')
+    @api.marshal_list_with(GET_PCVE, skip_none=True)
     @api.doc("API to list probable CVEs")
     def get(self): # pylint: disable=no-self-use
         """API to list probable CVEs"""

--- a/src/rest_model.py
+++ b/src/rest_model.py
@@ -40,7 +40,7 @@ PARSER.add_argument('to_date', type=from_date_str, help='Updated range - to')
 PARSER.add_argument('repo', type=str, action='append', help='Repository name')
 PARSER.add_argument('event_type', type=str, choices=(EventType._member_names_), help='Event type')
 
-POST_FEEDBACK = api.model('FEEDBACK', {
+POST_FEEDBACK = api.model('POST_FEEDBACK', {
     'author': fields.String(description='User id of the feedback provider', default='anonymous'),
     'comments': fields.String(attribute=lambda x: unsanitize(x['comments']),
                               description='Feedback text'),
@@ -50,7 +50,7 @@ POST_FEEDBACK = api.model('FEEDBACK', {
     'identified_cve': fields.String(description='Actual CVE details if exists')
 })
 
-GET_FEEDBACK = api.model('FEEDBACK', {
+GET_FEEDBACK = api.model('GET_FEEDBACK', {
     'author': fields.String(description='User id of the feedback provider', default='anonymous',
                             attribute=lambda x: x['author'][0]),
     'comments': fields.String(attribute=lambda x: unsanitize(x['comments'][0]),

--- a/src/rest_model.py
+++ b/src/rest_model.py
@@ -4,7 +4,7 @@ from src.app import api
 
 from src.graph_model import FeedBackType, EventType
 from src.parse_datetime import to_date_str, from_date_str
-from src.sanitizer import unsanitize
+from src.unroll_property import value, unsanitized_value
 
 # pylint: disable=no-member,protected-access
 POST_PCVE = api.model('PCVE', {
@@ -25,7 +25,7 @@ POST_PCVE = api.model('PCVE', {
 
 class ISO8601Format(fields.Raw):
     """Abstracts iso8601 string formatting"""
-    def format(self, value):
+    def format(self, value): # pylint: disable=redefined-outer-name
         """Converts given epoch to iso8601 string"""
         return to_date_str(value)
 
@@ -42,8 +42,7 @@ PARSER.add_argument('event_type', type=str, choices=(EventType._member_names_), 
 
 POST_FEEDBACK = api.model('POST_FEEDBACK', {
     'author': fields.String(description='User id of the feedback provider', default='anonymous'),
-    'comments': fields.String(attribute=lambda x: unsanitize(x['comments']),
-                              description='Feedback text'),
+    'comments': fields.String(description='Feedback text'),
     'url': fields.String(description='Github Issue/PR/Commit absolute(fully qualified) URL'),
     'feedback_type': fields.String(description='Feedback type',
                                    enum=FeedBackType._member_names_),
@@ -52,31 +51,30 @@ POST_FEEDBACK = api.model('POST_FEEDBACK', {
 
 GET_FEEDBACK = api.model('GET_FEEDBACK', {
     'author': fields.String(description='User id of the feedback provider', default='anonymous',
-                            attribute=lambda x: x['author'][0]),
-    'comments': fields.String(attribute=lambda x: unsanitize(x['comments'][0]),
+                            attribute=value('author')),
+    'comments': fields.String(attribute=unsanitized_value('comments'),
                               description='Feedback text'),
     'feedback_type': fields.String(description='Feedback type',
-                                   attribute=lambda x: x['feedback_type'][0],
+                                   attribute=value('feedback_type'),
                                    enum=FeedBackType._member_names_),
 })
 
 GET_PCVE = api.model('GET_PCVE', {
     'ecosystem': fields.String(description='Ecosystem'),
-    'repo_name': fields.String(attribute=lambda x: x['dependency']['dependency_name'][0],
+    'repo_name': fields.String(attribute=value('dependency.dependency_name'),
                                description='Repository Name'),
-    'event_type': fields.String(attribute=lambda x: x['security_event']['event_type'][0],
+    'event_type': fields.String(attribute=value('security_event.event_type'),
                                 description='Event Type', enum=EventType._member_names_),
-    'status': fields.String(attribute=lambda x: x['security_event']['status'][0],
+    'status': fields.String(attribute=value('security_event.status'),
                             description='Status'),
-    'url': fields.String(attribute=lambda x: unsanitize(x['security_event']['url'][0]),
+    'url': fields.String(attribute=unsanitized_value('security_event.url'),
                          description='url'),
-    'event_id': fields.String(attribute=lambda x: x['security_event']['event_id'][0],
+    'event_id': fields.String(attribute=value('security_event.event_id'),
                               description='Event Id from Github'),
-    'probable_vuln_id': fields.String(attribute=lambda x: \
-                                        x['probable_vulnerability']['probable_vuln_id'][0],
+    'probable_vuln_id': fields.String(attribute=value('probable_vulnerability.probable_vuln_id'),
                                       description='Probable vulnerability ID'),
-    'created_at': ISO8601Format(attribute=lambda x: x['security_event']['created_at'][0]),
-    'updated_at': ISO8601Format(attribute=lambda x: x['security_event']['updated_at'][0]),
-    'closed_at': ISO8601Format(attribute=lambda x: x['security_event']['closed_at'][0]),
+    'created_at': ISO8601Format(attribute=value('security_event.created_at')),
+    'updated_at': ISO8601Format(attribute=value('security_event.updated_at')),
+    'closed_at': ISO8601Format(attribute=value('security_event.closed_at')),
     'feedback': fields.Nested(GET_FEEDBACK)
 })

--- a/src/rest_model.py
+++ b/src/rest_model.py
@@ -50,21 +50,33 @@ POST_FEEDBACK = api.model('FEEDBACK', {
     'identified_cve': fields.String(description='Actual CVE details if exists')
 })
 
+GET_FEEDBACK = api.model('FEEDBACK', {
+    'author': fields.String(description='User id of the feedback provider', default='anonymous',
+                            attribute=lambda x: x['author'][0]),
+    'comments': fields.String(attribute=lambda x: unsanitize(x['comments'][0]),
+                              description='Feedback text'),
+    'feedback_type': fields.String(description='Feedback type',
+                                   attribute=lambda x: x['feedback_type'][0],
+                                   enum=FeedBackType._member_names_),
+})
+
 GET_PCVE = api.model('GET_PCVE', {
     'ecosystem': fields.String(description='Ecosystem'),
-    'repo_name': fields.String(attribute='dependency.dependency_name',
+    'repo_name': fields.String(attribute=lambda x: x['dependency']['dependency_name'][0],
                                description='Repository Name'),
-    'event_type': fields.String(attribute='security_event.event_type',
+    'event_type': fields.String(attribute=lambda x: x['security_event']['event_type'][0],
                                 description='Event Type', enum=EventType._member_names_),
-    'status': fields.String(attribute='security_event.status', description='Status'),
-    'url': fields.String(attribute=lambda x: unsanitize(x['security_event']['url']),
+    'status': fields.String(attribute=lambda x: x['security_event']['status'][0],
+                            description='Status'),
+    'url': fields.String(attribute=lambda x: unsanitize(x['security_event']['url'][0]),
                          description='url'),
-    'event_id': fields.String(attribute='security_event.event_id',
+    'event_id': fields.String(attribute=lambda x: x['security_event']['event_id'][0],
                               description='Event Id from Github'),
-    'probable_vuln_id': fields.String(attribute='probable_vulnerability.probable_vuln_id',
+    'probable_vuln_id': fields.String(attribute=lambda x: \
+                                        x['probable_vulnerability']['probable_vuln_id'][0],
                                       description='Probable vulnerability ID'),
-    'created_at': ISO8601Format(attribute='security_event.created_at'),
-    'updated_at': ISO8601Format(attribute='security_event.updated_at'),
-    'closed_at': ISO8601Format(attribute='security_event.closed_at'),
-    'feedback': fields.Nested(POST_FEEDBACK)
+    'created_at': ISO8601Format(attribute=lambda x: x['security_event']['created_at'][0]),
+    'updated_at': ISO8601Format(attribute=lambda x: x['security_event']['updated_at'][0]),
+    'closed_at': ISO8601Format(attribute=lambda x: x['security_event']['closed_at'][0]),
+    'feedback': fields.Nested(GET_FEEDBACK)
 })

--- a/src/unroll_property.py
+++ b/src/unroll_property.py
@@ -1,0 +1,26 @@
+"""Helper functions to unroll gremlin list property"""
+
+from src.sanitizer import unsanitize
+
+def value(keys):
+    """Nested dictionary keys who's value to be unrolled"""
+    def _get(obj) -> str:
+        try:
+            for key in keys.split('.'):
+                obj = obj[key]
+            # old versions of gremlin don't have proper way to
+            # unroll a list to value who's size is 1.
+            return obj[0]
+        except (IndexError, TypeError, KeyError):
+            pass
+        return None
+    return _get
+
+def unsanitized_value(keys):
+    """Nested dictionary keys who's value to be unrolled and unsanitized"""
+    def _get(obj) -> str:
+        try:
+            return unsanitize(value(keys)(obj))
+        except TypeError:
+            return None
+    return _get

--- a/tests/src/unroll_property_test.py
+++ b/tests/src/unroll_property_test.py
@@ -1,0 +1,42 @@
+"""Tests list property unroller"""
+
+import pytest
+
+from src.unroll_property import value, unsanitized_value
+
+# pylint: disable=missing-function-docstring
+VALUE_TESTDATA = [
+        ({}, 'foo', None),
+        (None, 'foo', None),
+        ('', 'foo', None),
+        ({'foo': 1}, 'foo', None),
+        ({'foo': [1]}, 'foo', 1),
+        ({'foo': ['hello']}, 'foo', 'hello'),
+        ({}, 'foo.bar', None),
+        (None, 'foo.bar', None),
+        ('', 'foo.bar', None),
+        ({'foo': {'bar': 1}}, 'foo.bar', None),
+        ({'foo': {'bar': [1]}}, 'foo.bar', 1),
+        ({'foo': {'bar': ['hello']}}, 'foo.bar', 'hello'),
+]
+@pytest.mark.parametrize("obj,key,expected", VALUE_TESTDATA)
+def test_value(obj, key, expected):
+    get = value(key)
+    assert expected == get(obj)
+
+UNSANITIZED_VALUE_TESTDATA = [
+        ({}, 'foo', None),
+        (None, 'foo', None),
+        ('', 'foo', None),
+        ({'foo': 1}, 'foo', None),
+        ({'foo': ['hello%20world']}, 'foo', 'hello world'),
+        ({}, 'foo.bar', None),
+        (None, 'foo.bar', None),
+        ('', 'foo.bar', None),
+        ({'foo': {'bar': 1}}, 'foo.bar', None),
+        ({'foo': {'bar': ['hello%20world']}}, 'foo.bar', 'hello world'),
+]
+@pytest.mark.parametrize("obj,key,expected", UNSANITIZED_VALUE_TESTDATA)
+def test_unsanitized_value(obj, key, expected):
+    get = unsanitized_value(key)
+    assert expected == get(obj)


### PR DESCRIPTION
Gremlin query to retrieve probable CVE is based on gremlin version 3.4.x. But it is not working on older versions of gremlin(3.2.3) which is hosted in dependency analytics openshift cluster.

In gremlin 3.2.x, there is no proper method to unfold property list if it has only one value., so it has to be fixed in the response model to handle the array of property.